### PR TITLE
Ensure FOV search, fixed FOV, and preloaded calibration produce identical output

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3751,7 +3751,7 @@ class PyplisWorker:
         # I will be able to process it too. Otherwise I can only process all but the final image, since I will need to
         # generate the optical flow)
         if self.idx_current < self.img_buff_size:
-            num_buff = self.idx_current - 1
+            num_buff = self.idx_current
         else:
             num_buff = self.img_buff_size
 

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2384,7 +2384,7 @@ class PyplisWorker:
             # TODO should include a tau vs cal flag check, to see whether the plot is displaying AA or ppmm
             self.fig_tau.update_plot(np.array(self.img_tau.img), img_cal=self.img_cal)
 
-    def calibrate_image(self, img, run_cal_doas=False, doas_update=True):
+    def calibrate_image(self, img, run_cal_doas=False, doas_update=True, calib_buff = False):
         """
         Takes tau image and calibrates it using correct calibration mode
         :param img: pyplis.Img or pyplis.ImgStack      Tau image
@@ -3788,7 +3788,7 @@ class PyplisWorker:
 
             # Calibrate image if it hasn't already been
             if not img_tau.is_calibrated:
-                img_cal = self.calibrate_image(img_tau, doas_update=False)
+                img_cal = self.calibrate_image(img_tau, doas_update=False, calib_buff=True)
 
                 # If the image hasn't already been calibrated we may want to save it if requested
                 if self.save_dict['img_cal']['save']:

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3763,7 +3763,7 @@ class PyplisWorker:
             # If time of image is before or equal to "after", we ignore it
             # If the results object already has emission rates for this time, we skip it if overwrite=False
             img_time = img_tau.meta['start_acq']
-            if img_time <= after:
+            if img_time < after:
                 continue
             if not overwrite:
                 velo_modes = [mode for mode in self.velo_modes if self.velo_modes[mode]]

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2420,6 +2420,17 @@ class PyplisWorker:
                 if self.doas_cal_adjust_offset:
                     cal_img.img = cal_img.img + self.calib_pears.y_offset
 
+                # The first time a calibration is available also calibrate the previous image,
+                # so an emission rate can be generated for it.
+                if not calib_buff and self.img_cal_prev is None:
+                    img_tau_prev = copy.deepcopy(self.img_tau_prev)
+                    cal_img_prev = self.calib_pears.calibrate(img_tau_prev)
+
+                    if self.doas_cal_adjust_offset:
+                        cal_img_prev.img = cal_img_prev.img + self.calib_pears.y_offset
+                    
+                    self.img_cal_prev = cal_img_prev
+
         elif self.cal_type_int == 0:
             if isinstance(img, pyplis.Img):
                 # cal_img = img * self.cell_fit[0]    # Just use cell gradient (not y axis intersect)

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2590,8 +2590,9 @@ class PyplisWorker:
         if (force_fov_cal or self.doas_fov_recal or not self.got_doas_fov) and not self.fix_fov:
             dt = datetime.timedelta(minutes=self.doas_fov_recal_mins)
             oldest_time = img_time - dt
-            with self.doas_worker.lock:
-                if oldest_time >= self.doas_last_fov_cal or force_fov_cal:
+            if oldest_time >= self.doas_last_fov_cal or force_fov_cal:
+                doas_result_avail = self.check_doas_result_avail(img_time)
+                with self.doas_worker.lock:
                     # Check we have some DOAS points
                     if len(self.doas_worker.results) < self.min_doas_points:
                         print('Require at least {} DOAS points to perform FOV CD-tau calibration. '

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -2022,6 +2022,10 @@ class PyplisWorker:
         for img in img_buff:
             stack.add_img(img['img_tau'], img['time'])
 
+        if self.img_tau_prev is not None:
+            stack.add_img(self.img_tau_prev, self.img_tau_prev.meta['start_acq'])
+            stack.add_img(self.img_tau, self.img_tau.meta['start_acq'])
+
         stack.img_prep['pyrlevel'] = 0
 
         return stack

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -3761,7 +3761,6 @@ class PyplisWorker:
         if after is None:
             after = datetime.datetime(2000, 1, 1)
 
-        # TODO I may want to think about deciding how far to loop through the buffer here
         # Define number of images to loop through (I can try to go to last image, and if it contains optical flow data
         # I will be able to process it too. Otherwise I can only process all but the final image, since I will need to
         # generate the optical flow)


### PR DESCRIPTION
Fixes #73
Fixes #94 

I think these changes address the discrepancies between post-processing runs where there is an FOV search, the FOV is fixed, and a pre-loaded calibration is used. The results include all time points (except the last one), and the results for these tome points are equivalent to 6 decimal places (which I think is mg/s).

The only remaining discrepancy is with the full calibration files, but from what I can tell these are very small differences, and do not affect the final output. I think it would be possible to iron out these, but If you're happy with the emissions outputs being identical then it's probably not worth the effort.