### PR TITLE
Pathlib fix

### DIFF
--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -102,7 +102,7 @@ class DOASWorker(SpecWorker):
         :param: plot    bool    If true, the first spectra are plotted in the GUI"""
 
         if prompt:
-            spec_dir = filedialog.askdirectory(title='Select spectrum sequence directory', initialdir=self.spec_dir)
+            spec_dir = filedialog.askdirectory(title='Select spectrum sequence directory', initialdir=str(self.spec_dir))
 
             if len(spec_dir) > 0 and os.path.exists(spec_dir):
                 self.spec_dir = Path(spec_dir)
@@ -478,9 +478,9 @@ class DOASWorker(SpecWorker):
 
         # Loop through all files and add them to queue
         for file in clear_spec:
-            self.q_spec.put(self.spec_dir / file)
+            self.q_spec.put(str(self.spec_dir / file))
         for file in plume_spec:
-            self.q_spec.put(self.spec_dir / file)
+            self.q_spec.put(str(self.spec_dir / file))
 
         # Add the exit flag at the end, to ensure that the process_loop doesn't get stuck waiting on the queue forever
         self.q_spec.put('exit')

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -14,6 +14,7 @@ import datetime
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
+from pathlib import Path
 from itertools import compress
 from tkinter import filedialog
 from scipy.interpolate import griddata
@@ -308,19 +309,18 @@ class IFitWorker(SpecWorker):
         :param: plot    bool    If true, the first spectra are plotted in the GUI
         :param: process_first   bool    If True, the first spectrum is processed.
         """
-
         if spec_dir is not None:
-            self.spec_dir = spec_dir
+            self.spec_dir = Path(spec_dir)
         elif prompt:
-            spec_dir = filedialog.askdirectory(title='Select spectrum sequence directory', initialdir=self.spec_dir)
+            spec_dir = filedialog.askdirectory(title='Select spectrum sequence directory', initialdir=str(self.spec_dir))
 
             if len(spec_dir) > 0 and os.path.exists(spec_dir):
-                self.spec_dir = spec_dir
+                self.spec_dir = Path(spec_dir)
             else:
                 raise ValueError('Spectrum directory not recognised: {}'.format(spec_dir))
         else:
             if self.spec_dir is None:
-                raise ValueError('Spectrum directory not recognised: {}'.format(self.spec_dir))
+                raise ValueError('Spectrum directory not recognised: {}'.format(str(self.spec_dir)))
 
         # Update first_spec flag TODO possibly not used in DOASWorker, check
         self.first_spec = True
@@ -332,11 +332,9 @@ class IFitWorker(SpecWorker):
 
         # Set current spectra to first in lists
         if len(self.spec_dict['clear']) > 0:
-            self.wavelengths, self.clear_spec_raw = load_spectrum(os.path.join(self.spec_dir,
-                                                                               self.spec_dict['clear'][0]))
+            self.wavelengths, self.clear_spec_raw = load_spectrum(str(self.spec_dir / self.spec_dict['clear'][0]))
         if len(self.spec_dict['plume']) > 0:
-            self.wavelengths, self.plume_spec_raw = load_spectrum(os.path.join(self.spec_dir,
-                                                                               self.spec_dict['plume'][0]))
+            self.wavelengths, self.plume_spec_raw = load_spectrum(str(self.spec_dir / self.spec_dict['plume'][0]))
             self.spec_time = self.get_spec_time(self.spec_dict['plume'][0])
 
             # Get respective dark spectrum
@@ -521,8 +519,7 @@ class IFitWorker(SpecWorker):
         for i in range(len(self.spec_dict['plume'])):
             print('Processing spectrum {} of {}'.format(i+1, len(self.spec_dict['plume'])))
 
-            self.wavelengths, self.plume_spec_raw = load_spectrum(os.path.join(self.spec_dir,
-                                                                               self.spec_dict['plume'][i]))
+            self.wavelengths, self.plume_spec_raw = load_spectrum(str(self.spec_dir / self.spec_dict['plume'][i]))
             self.spec_time = self.get_spec_time(self.spec_dict['plume'][i])
 
             # Get dark spectrum
@@ -641,7 +638,7 @@ class IFitWorker(SpecWorker):
         """
         if filename is None:
             filename = filedialog.askopenfilename(title='Select DOAS results file',
-                                                  initialdir=self.spec_dir, filetypes=(('csv', '*.csv'),
+                                                  initialdir=str(self.spec_dir), filetypes=(('csv', '*.csv'),
                                                                                        ('All files', '*.*')))
             if not filename:
                 return
@@ -673,7 +670,7 @@ class IFitWorker(SpecWorker):
         function can update the plots wihtout going through the main thread in PyplisWorker
         """
         if spec_dir is not None:
-            self.spec_dir = spec_dir
+            self.spec_dir = Path(spec_dir)
 
         # Flag that we are running processing outside of thread
         self.processing_in_thread = False
@@ -693,9 +690,9 @@ class IFitWorker(SpecWorker):
 
         # Loop through all files and add them to queue
         for file in clear_spec:
-            self.q_spec.put(os.path.join(self.spec_dir, file))
+            self.q_spec.put(str(self.spec_dir / file))
         for file in plume_spec:
-            self.q_spec.put(os.path.join(self.spec_dir, file))
+            self.q_spec.put(str(self.spec_dir / file))
 
         # Add the exit flag at the end, to ensure that the process_loop doesn't get stuck waiting on the queue forever
         self.q_spec.put(self.STOP_FLAG)
@@ -747,7 +744,7 @@ class IFitWorker(SpecWorker):
                 #print('IFitWorker: processing spectrum: {}'.format(pathname))
                 # Extract filename and create datetime object of spectrum time
                 working_dir, filename = os.path.split(pathname)
-                self.spec_dir = working_dir     # Update working directory to where most recent file has come from
+                self.spec_dir = Path(working_dir)     # Update working directory to where most recent file has come from
 
                 spec_time = self.get_spec_time(filename)
 
@@ -1406,7 +1403,7 @@ if __name__ == '__main__':
     ifit_worker.end_fit_wave = 320
 
     # Process directory
-    ifit_worker.process_dir(spec_dir=spec_path)
+    ifit_worker.process_dir(spec_dir=Path(spec_path))
     # ifit_worker.start_processing_threadless(spec_dir=spec_path)
 
     # ------------

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -389,7 +389,7 @@ class SpecWorker:
         sd = {}
 
         # Get all files into associated list/dictionary entry
-        sd['all'] = [f for f in os.listdir(self.spec_dir) if self.spec_specs.file_ext in f]
+        sd['all'] = [f for f in os.listdir(str(self.spec_dir)) if self.spec_specs.file_ext in f]
         sd['all'].sort()
         sd['plume'] = [f for f in sd['all']
                        if self.spec_specs.file_type['meas'] + self.spec_specs.file_ext in f]
@@ -438,7 +438,7 @@ class SpecWorker:
         subdir = 'Processed_spec_{}'
         process_time = datetime.datetime.now().strftime(self.save_date_fmt)
         # Save this as an attribute so we only have to generate it once
-        self.doas_outdir = os.path.join(path, subdir.format(process_time))
+        self.doas_outdir = str(Path(path) / subdir.format(process_time))
         if make_dir:
             os.mkdir(self.doas_outdir)
 

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -6,6 +6,7 @@ import os
 import threading
 import numpy as np
 import pandas as pd
+from pathlib import Path
 from astropy.convolution import convolve
 from pycam.setupclasses import SpecSpecs
 from pydoas.analysis import DoasResults
@@ -20,7 +21,7 @@ class SpecWorker:
     """
     Parent class for IfitWorker and DoasWorker
     """
-    def __init__(self, routine=2, species={'SO2': {'path': '', 'value': 0}}, spec_specs=SpecSpecs(), spec_dir='C:\\', dark_dir=None,
+    def __init__(self, routine=2, species={'SO2': {'path': '', 'value': 0}}, spec_specs=SpecSpecs(), spec_dir=None, dark_dir=None,
                  q_doas=queue.Queue()):
         self.routine = routine          # Defines routine to be used, either (1) Polynomial or (2) Digital Filtering
         self.spec_specs = spec_specs    # Spectrometer specifications
@@ -117,7 +118,10 @@ class SpecWorker:
 
         self._dark_dir = None
         self.dark_dir = dark_dir        # Directory where dark images are stored
-        self.spec_dir = spec_dir        # Directory where plume spectra are stored
+        if spec_dir:
+            self.spec_dir = Path(spec_dir)        # Directory where plume spectra are stored
+        else:
+            self.spec_dir = None
         self.spec_dict = {}             # Dictionary containing all spectrum files from current spec_dir
 
         # Figures

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -25,6 +25,7 @@ from pyplis.fluxcalc import det_emission_rate, MOL_MASS_SO2, N_A, EmissionRates
 from pyplis.doascalib import DoasCalibData, DoasFOV
 from pyplis.exceptions import ImgMetaError
 
+from pathlib import Path
 import pandas as pd
 from math import log10, floor
 import datetime
@@ -531,6 +532,7 @@ class PyplisWorker:
         current_params = {key: getattr(self.doas_worker, value)
                           for key, value in doas_params.items()}
         self.config.update(current_params)
+        self.config['spec_dir'] = str(doas_params['spec_dir'])
 
     def save_config_plus(self, file_path, file_name = None):
         """Save extra data associated with config file along with config"""
@@ -554,7 +556,7 @@ class PyplisWorker:
             vals = {key: self.config[key] for key in subset if key in self.config.keys()}
             self.raw_configs["default"].update(vals)
 
-        full_path = os.path.join(file_path, file_name)
+        full_path = str(Path(file_path) / file_name)
 
         with open(full_path, "w") as file:
             yaml.dump(self.raw_configs["default"], file)


### PR DESCRIPTION
closes #263 

Fixes Windows and Mac/Linux path seporators being mixed by swapping `os.path.join` operations with `Pathlib.Path` operations