### PR TITLE
change mount path to StorageMount class variable (#262)

### DIFF
--- a/pycam/gui/cfg.py
+++ b/pycam/gui/cfg.py
@@ -34,7 +34,7 @@ current_dir_spec = CurrentDirectories(root=config[ConfigInfo.local_data_dir], sp
 
 # FTP client
 ftp_client = FTPClient(img_dir=current_dir_img, spec_dir=current_dir_spec, network_info=config,
-                       storage_mount_data_path=StorageMount.mount_path)
+                       storage_mount_data_path=StorageMount.data_path)
 
 # FTP client for 2nd pi
 config_2 = copy.deepcopy(config)

--- a/pycam/gui/cfg.py
+++ b/pycam/gui/cfg.py
@@ -34,7 +34,7 @@ current_dir_spec = CurrentDirectories(root=config[ConfigInfo.local_data_dir], sp
 
 # FTP client
 ftp_client = FTPClient(img_dir=current_dir_img, spec_dir=current_dir_spec, network_info=config,
-                       storage_mount=StorageMount())
+                       storage_mount_data_path=StorageMount.mount_path)
 
 # FTP client for 2nd pi
 config_2 = copy.deepcopy(config)

--- a/pycam/networking/FTP.py
+++ b/pycam/networking/FTP.py
@@ -305,7 +305,7 @@ class FTPClient:
     :param network_info:    dict                Contains network parameters defining information for FTP transfer
     """
 
-    def __init__(self, img_dir, spec_dir, network_info=None, storage_mount_data_path=StorageMount.mount_path):
+    def __init__(self, img_dir, spec_dir, network_info=None, storage_mount_data_path=StorageMount.data_path):
         # TODO Need a way of changing the IP address this connects to - this should be linked to sock ip somehow
 
         self.refresh_time = 1   # Length of time directory watcher sleeps before listing server images again

--- a/pycam/networking/FTP.py
+++ b/pycam/networking/FTP.py
@@ -305,13 +305,13 @@ class FTPClient:
     :param network_info:    dict                Contains network parameters defining information for FTP transfer
     """
 
-    def __init__(self, img_dir, spec_dir, network_info=None, storage_mount=StorageMount()):
+    def __init__(self, img_dir, spec_dir, network_info=None, storage_mount_data_path=StorageMount.mount_path):
         # TODO Need a way of changing the IP address this connects to - this should be linked to sock ip somehow
 
         self.refresh_time = 1   # Length of time directory watcher sleeps before listing server images again
         self.cam_specs = CameraSpecs()
         self.spec_specs = SpecSpecs()
-        self.storage_mount = storage_mount
+        self.storage_mount_data_path = storage_mount_data_path
         self.watch_q = queue.Queue()
         self.thread = None
         self.watching_dir = False
@@ -655,12 +655,12 @@ class FTPClient:
 
         # Change working directory to mounted SSD device
         try:
-            self.connection.cwd(self.storage_mount.data_path)
+            self.connection.cwd(self.storage_mount_data_path)
         except BaseException as e:
             messagebox.showerror('Error in data download',
                                  'The following error was thrown when attempting to find data on SSD ({}): {}\n'
                                  'Please ensure that the device is mounted '
-                                 'on the R-Pi.'.format(self.storage_mount.data_path, e))
+                                 'on the R-Pi.'.format(self.storage_mount_data_path, e))
             return
 
         # List directories
@@ -693,7 +693,7 @@ class FTPClient:
         num_files = 0
         for dir_num, date_dir in enumerate(dir_list):
             # Set directory
-            current_dir = self.storage_mount.data_path + '/' + date_dir
+            current_dir = self.storage_mount_data_path + '/' + date_dir
             print('Getting data from date: {}'.format(date_dir))
 
             # Change working directory to date directory with data in
@@ -724,7 +724,7 @@ class FTPClient:
             frame.update()
 
             # Change working directory back to starting point
-            self.connection.cwd(self.storage_mount.data_path)
+            self.connection.cwd(self.storage_mount_data_path)
 
         # Close loading widget
         frame.destroy()

--- a/pycam/utils.py
+++ b/pycam/utils.py
@@ -303,12 +303,13 @@ class StorageMount:
     Basic class to control the handling of mounting external memory and storing details of mounted drive
     """
     mount_path = '/mnt/pycam/'
+    data_path = '/mnt/pycam/data/'
 
     def __init__(self, mount_path=None, dev_path=None):
         self.dev_path = dev_path
         if mount_path:
             self.mount_path = mount_path
-        self.data_path = os.path.join(self.mount_path, 'data')
+            self.data_path = os.path.join(self.mount_path, 'data')
         self.lock = threading.Lock()
 
         if self.dev_path is None:

--- a/pycam/utils.py
+++ b/pycam/utils.py
@@ -302,9 +302,12 @@ class StorageMount:
     """
     Basic class to control the handling of mounting external memory and storing details of mounted drive
     """
-    def __init__(self, mount_path='/mnt/pycam/', dev_path=None):
+    mount_path = '/mnt/pycam/'
+
+    def __init__(self, mount_path=None, dev_path=None):
         self.dev_path = dev_path
-        self.mount_path = mount_path
+        if mount_path:
+            self.mount_path = mount_path
         self.data_path = os.path.join(self.mount_path, 'data')
         self.lock = threading.Lock()
 


### PR DESCRIPTION
This PR changes `StorageMount` to have a class variable that contains the location of the mounted SSD on the Raspberry Pi. This lets the `FTPClient` class access this information without creating an instance of `StorageMount` when loading the GUI.

This PR addresses issue #262  where loading the GUI prompted for a password in `sudo`, which occurred as a result of  `StorageMount.__init__()` calling `StorageMount.find_dev()`. `find_dev()` is only applicable to running on the Raspberry Pi and should not be executed by the GUI.