### PR TITLE
only require pywin32 on windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ srtm.py
 watchdog
 parameterized
 dropbox
-pywin32
+pywin32 ; sys_platform == 'win32'
 pyplis @ git+https://github.com/volcanotech-sw/pyplis.git@sources_fix
 pydoas @ git+https://github.com/volcanotech-sw/pydoas.git
 iFit @ git+https://github.com/volcanotech-sw/iFit.git@make-pip-install

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ watchdog
 parameterized
 dropbox
 pywin32 ; sys_platform == 'win32'
+pyinotify ; sys_platform == 'linux'
 pyplis @ git+https://github.com/volcanotech-sw/pyplis.git@sources_fix
 pydoas @ git+https://github.com/volcanotech-sw/pydoas.git
 iFit @ git+https://github.com/volcanotech-sw/iFit.git@make-pip-install


### PR DESCRIPTION
The win32 API is used as part of the directory watching code. This looks to have conditional logic in place for if the code is running on Windows and should use pywin32 or if it's running on Linux and should use pyinotify instead.

https://github.com/volcanotech-sw/PyCamPermanent/blob/71a3ae6ecca7fa9331ddaf03adfa84bcdcc50f89/pycam/directory_watcher.py#L37-L52

This PR makes the pywin32 dependency similarly conditional, so that `pip install -r requirements.txt` can be run on Linux as suggested in #254.

I've tested this on Ubuntu Linux 20.04 and Windows 10 and had the expected behaviour on Linux with pip reporting `Ignoring pywin32: markers 'sys_platform == "win32"' don't match your environment` and pywin32 being installed on Windows and being able to run `import win32` without error.