### PR TITLE
Issue 275 fit ils

### DIFF
--- a/pycam/conf/processing_setting_defaults.yml
+++ b/pycam/conf/processing_setting_defaults.yml
@@ -56,6 +56,7 @@ auto_bg_cmap: 0
 # DOAS calibration and DOAS-AA calibration
 doas_method: ifit
 ILS_path: .\pycam\tests\test_data\test_spectra\2019-07-03_302nm_ILS.txt
+include_ils_fit: false
 maxrad_doas: 1.0
 remove_doas_mins: 30
 doas_recal: 1

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -107,6 +107,7 @@ class IFitWorker(SpecWorker):
         # TODO perhaps the error is retrieved differently when these parameters are used, but I'm not sure why that would be...
         # TODO I have made a work around to pop these parameters from self.params if generating our own ILS
         # Add ILS parameters
+        self.include_ils_fit = True
         self.ils_params = {
             'fwem': 0.6,
             'k': 2.0,
@@ -114,7 +115,7 @@ class IFitWorker(SpecWorker):
             'a_k': 0.0
         }
         for key in self.ils_params:
-            self.params.add(key, value=self.ils_params[key], vary=True)
+            self.params.add(key, value=self.ils_params[key], vary=True)  # With vary=True this will fit the ILS in the fit procedure
 
         # Setup ifit analyser (we will stray correct ourselves
         self.analyser = Analyser(params=self.params,
@@ -896,7 +897,7 @@ class IFitWorker(SpecWorker):
         NOTE: I cannot just adjust the fit_window attribute as the model is generated
         """
         # TODO perhaps requst ben adds an update fit window func to update the analyser without creating a new object
-        if self.ils_path is not None:
+        if not self.include_ils_fit and self.ils_path is not None:
             self.remove_ils_params()
             self.analyser = Analyser(params=self.params,
                                      fit_window=[self._start_fit_wave_init, self._end_fit_wave_init],
@@ -931,16 +932,8 @@ class IFitWorker(SpecWorker):
 
     def load_ils(self, ils_path):
         """Load ils from path"""
-        self.remove_ils_params()
-        self.analyser = Analyser(params=self.params,
-                                 fit_window=[self._start_fit_wave_init, self._end_fit_wave_init],
-                                 frs_path=self.frs_path,
-                                 stray_flag=False,      # We stray correct prior to passing spectrum to Analyser
-                                 dark_flag=False,
-                                 ils_type='File',
-                                 ils_path=ils_path)
-
         self.ils_path = ils_path
+        self.update_analyser()
 
         # Load ILS
         self.ILS_wavelengths, self.ILS = np.loadtxt(ils_path, unpack=True)

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -107,7 +107,6 @@ class IFitWorker(SpecWorker):
         # TODO perhaps the error is retrieved differently when these parameters are used, but I'm not sure why that would be...
         # TODO I have made a work around to pop these parameters from self.params if generating our own ILS
         # Add ILS parameters
-        self.include_ils_fit = True
         self.ils_params = {
             'fwem': 0.6,
             'k': 2.0,

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -74,6 +74,7 @@ class SpecWorker:
         self.abs_spec_species = dict()  # Dictionary of absorbances isolated for individual species
         self.ILS_wavelengths = None     # Wavelengths for ILS
         self._ILS = None                 # Instrument line shape (will be a numpy array)
+        self.include_ils_fit = False    # Whether to include ILS as part of the fit parameters (if False, an ILS must be provided via file)
         self.processed_data = False     # Bool to define if object has processed DOAS yet - will become true once process_doas() is run
 
         self.start_ca = -2000  # Starting column amount for iterations
@@ -370,6 +371,15 @@ class SpecWorker:
         shift_val = config.get("shift")
         if shift_val is not None:
             setattr(self, "shift", shift_val)
+
+    def set_ils_fit(self, config):
+        """Sets whether ILS is part of the fit parameters or if a predefined ILS is used in the iFit retrieval"""
+        self.include_ils_fit = config.get("include_ils_fit")
+        # Attempt to update analyser with new setting. If using DOASWorker this won't be possible, so using try/except
+        try:
+            self.update_analyser()
+        except AttributeError:
+            pass
 
     def reset_stray_pix(self):
         self._start_stray_pix = None

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -73,8 +73,8 @@ class SpecWorker:
         self.abs_spec_filt = None
         self.abs_spec_species = dict()  # Dictionary of absorbances isolated for individual species
         self.ILS_wavelengths = None     # Wavelengths for ILS
-        self._ILS = None                 # Instrument line shape (will be a numpy array)
-        self.include_ils_fit = False    # Whether to include ILS as part of the fit parameters (if False, an ILS must be provided via file)
+        self._ILS = None                # Instrument line shape (will be a numpy array)
+        self._include_ils_fit = False   # Whether to include ILS as part of the fit parameters (if False, an ILS must be provided via file)
         self.processed_data = False     # Bool to define if object has processed DOAS yet - will become true once process_doas() is run
 
         self.start_ca = -2000  # Starting column amount for iterations
@@ -245,6 +245,19 @@ class SpecWorker:
         # If new ILS is generated, then must flag that ref spectrum is no longer convolved with up-to-date ILS
         self.ref_convolved = False
 
+    @property
+    def include_ils_fit(self):
+        return self._include_ils_fit
+
+    @include_ils_fit.setter
+    def include_ils_fit(self, value):
+        self._include_ils_fit = value
+        # Attempt to update analyser with new setting. If using DOASWorker this won't be possible, so using try/except
+        try:
+            self.update_analyser()
+        except AttributeError:
+            pass
+
     def get_spec_time(self, filename):
         """
         Gets time from filename and converts it to datetime object
@@ -375,11 +388,6 @@ class SpecWorker:
     def set_ils_fit(self, config):
         """Sets whether ILS is part of the fit parameters or if a predefined ILS is used in the iFit retrieval"""
         self.include_ils_fit = config.get("include_ils_fit")
-        # Attempt to update analyser with new setting. If using DOASWorker this won't be possible, so using try/except
-        try:
-            self.update_analyser()
-        except AttributeError:
-            pass
 
     def reset_stray_pix(self):
         self._start_stray_pix = None

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -1014,12 +1014,22 @@ class ILSFrame:
         if self.ILS_path is not None:
             self.load_ILS()
 
+    def initiate_variables(self):
+        """Sets up tkinter variables that are used by this frame"""
+        self._include_ils_fit = tk.BooleanVar()
+
+    def gather_vars(self):
+        """Gets current settings for relevant attributes"""
+        self.include_ils_fit = self.doas_worker.include_ils_fit
+
     def generate_frame(self, parent):
         """
         Creates widget
         :param parent:  tk.Frame    Parent frame to place widget in
         :return:
         """
+        self.gather_vars()
+
         self.parent = parent
         self.frame = ttk.Frame(self.parent)
         self.in_frame = True
@@ -1115,6 +1125,9 @@ class ILSFrame:
         self.frame_ILS_func = ttk.Frame(self.frame_ILS, relief=tk.GROOVE, borderwidth=5)
         self.frame_ILS_func.pack(side=tk.LEFT, anchor='n')
 
+        self.ils_fit_check = ttk.Checkbutton(self.frame_ILS_func, text='Make ILS a fitted parameter',
+                                             variable=self._include_ils_fit, command=self.set_ILS_fit)
+
         label1 = tk.Label(self.frame_ILS_func, text='Loaded ILS file:')
         self.ILS_load_label = tk.Label(self.frame_ILS_func, text='N/A', width=self.str_len_max)
         self.load_ILS_button = ttk.Button(self.frame_ILS_func, text='Load ILS', command=self.choose_ILS)
@@ -1123,13 +1136,18 @@ class ILSFrame:
         self.ILS_save_label = tk.Label(self.frame_ILS_func, text='N/A', width=self.str_len_max)
         self.save_ILS_button = ttk.Button(self.frame_ILS_func, text='Save ILS', command=self.save_ILS)
 
-        label1.grid(row=0, column=0, sticky='w', padx=5, pady=5)
-        self.ILS_load_label.grid(row=0, column=1, padx=5, pady=5)
-        self.load_ILS_button.grid(row=0, column=2, padx=5, pady=5)
+        row = 0
+        self.ils_fit_check.grid(row=row, column=0, columnspan=3, sticky='w', padx=5, pady=5)
 
-        label2.grid(row=1, column=0, sticky='w', padx=5, pady=5)
-        self.ILS_save_label.grid(row=1, column=1, padx=5, pady=5)
-        self.save_ILS_button.grid(row=1, column=2, padx=5, pady=5)
+        row += 1
+        label1.grid(row=row, column=0, sticky='w', padx=5, pady=5)
+        self.ILS_load_label.grid(row=row, column=1, padx=5, pady=5)
+        self.load_ILS_button.grid(row=row, column=2, padx=5, pady=5)
+
+        row += 1
+        label2.grid(row=row, column=0, sticky='w', padx=5, pady=5)
+        self.ILS_save_label.grid(row=row, column=1, padx=5, pady=5)
+        self.save_ILS_button.grid(row=row, column=2, padx=5, pady=5)
 
         # PLOT
         self.fig_ILS = plt.Figure(figsize=self.ILS_figsize, dpi=self.dpi)
@@ -1151,6 +1169,14 @@ class ILSFrame:
         # Update label and plot as the ILS should be preloaded on startup
         self.update_ILS_label()
         self.update_ILS_plot()
+
+    @property
+    def include_ils_fit(self):
+        return self._include_ils_fit.get()
+
+    @include_ils_fit.setter
+    def include_ils_fit(self, value):
+        self._include_ils_fit.set(value)
 
     def dark_capture(self):
         """Implements dark capture fom spectrometer"""
@@ -1278,3 +1304,6 @@ class ILSFrame:
         self.ax_ILS.lines[0].set_data(self.doas_worker.ILS_wavelengths, self.doas_worker.ILS)
         self.ax_ILS.set_xlim([0, self.doas_worker.ILS_wavelengths[-1]])
         self.canv_ILS.draw()
+
+    def set_ILS_fit(self):
+        self.doas_worker.include_ils_fit = self.include_ils_fit

--- a/pycam/gui/menu.py
+++ b/pycam/gui/menu.py
@@ -796,6 +796,7 @@ class LoadFrame(LoadSaveProcessingSettings):
         self.main_gui.set_transfer_dir()
         self.doas_worker.get_wavelengths(pyplis_worker.config)
         self.doas_worker.get_shift(pyplis_worker.config)
+        self.doas_worker.set_ils_fit(pyplis_worker.config)
         self.main_gui.spec_wind.spec_frame.update_all()
         self.main_gui.spec_wind.doas_frame.update_vals()
 

--- a/pycam/gui/pycam_gui.py
+++ b/pycam/gui/pycam_gui.py
@@ -129,6 +129,7 @@ class PyCam(ttk.Frame):
         doas_worker.load_dir(prompt=False, plot=True)
         doas_worker.get_wavelengths(pyplis_worker.config)
         doas_worker.get_shift(pyplis_worker.config)
+        doas_worker.set_ils_fit(pyplis_worker.config)
         self.spec_wind.spec_frame.update_all()
         self.spec_wind.doas_frame.update_vals()
         doas_worker.process_doas(plot=True)

--- a/pycam/gui/pycam_gui.py
+++ b/pycam/gui/pycam_gui.py
@@ -106,6 +106,7 @@ class PyCam(ttk.Frame):
         geom_settings.initiate_variables(self)
         process_settings.initiate_variables(self)
         calibration_wind.add_gui(self)
+        calibration_wind.ils_frame.initiate_variables()
         plume_bg.initiate_variables(self)
         plume_bg.start_draw(self.root)
         doas_fov.start_draw(self.root)      # start drawing of frame

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -516,6 +516,7 @@ class PyplisWorker:
             "spec_dir": "spec_dir",
             "dark_spec_dir": "dark_dir",
             "ILS_path": "ils_path",
+            "include_ils_fit": "include_ils_fit",
             "use_light_dilution_spec": "corr_light_dilution",
             "grid_max_ppmm": "grid_max_ppmm",
             "grid_increment_ppmm": "grid_increment_ppmm",


### PR DESCRIPTION
@ubdbra001 The only thing I haven't quite got sorted is the warning box doesn't seem to pop up if you load a config file that doesn't have `include_ils_fit` attribute in it. Can you think why this might be?

Other than that this works well - you can toggle the ILS fit on and off in Prcoessing Settings > Calibration > DOAS calibration using the check box next to the ILS figure. DOAS results are slightly different if you process the default sequence with this on and off.