### PR TITLE
Issue 278 dark subtraction

### DIFF
--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -1122,8 +1122,11 @@ class PyplisWorker:
                 img.subtract_dark_image(dark_img)
                 img.img[img.img <= 0] = np.finfo(float).eps
             else:
-                warnings.warn('No dark image provided for background image.\n '
-                              'Background image has not been corrected for dark current.')
+                warnings.warn('No dark image found, for band {} background image.'
+                              'Note: Image will still be flagged as dark-corrected so processing can proceed.'.format(band))
+                img.subtract_dark_image(0)  # Just subtract 0. This ensures the image is flagged as dark-corr
+        else:
+            img.subtract_dark_image(0)  # Just subtract 0. This ensures the image is flagged as dark-corr
 
         # Set variables
         setattr(self, 'bg_{}'.format(band), img)

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -1575,7 +1575,11 @@ class PyplisWorker:
 
             # Find associated dark image by extracting shutter speed, then subtract this image
             ss = meta['texp'] / self.cam_specs.file_ss_units
-            img_array_clear_A[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band='A')[0]
+            try:
+                img_array_clear_A[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band='A')[0]
+            except np.core._exceptions._UFuncOutputCastingError:
+                print('Unable to find dark image for cell calibration in '
+                              'band A exposure {}. Image will not be dark-subtracted'.format(ss))
 
             # Scale image to 1 second exposure (so that we can deal with images of different shutter speeds
             img_array_clear_A[:, :, i] *= (1 / meta['texp'])
@@ -1589,7 +1593,12 @@ class PyplisWorker:
 
             # Find associated dark image by extracting shutter speed, then subtract this image
             ss = meta['texp'] / self.cam_specs.file_ss_units
-            img_array_clear_B[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band='B')[0]
+            try:
+                img_array_clear_B[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band='B')[0]
+            except np.core._exceptions._UFuncOutputCastingError:
+                print('Unable to find dark image for cell calibration in '
+                              'band B exposure {}. Image will not be dark-subtracted'.format(ss))
+
 
             # Scale image to 1 second exposure (so that we can deal with images of different shutter speeds
             img_array_clear_B[:, :, i] *= (1 / meta['texp'])
@@ -1664,7 +1673,12 @@ class PyplisWorker:
 
                     # Find associated dark image by extracting shutter speed, then subtract this image
                     ss = meta['texp'] / self.cam_specs.file_ss_units
-                    cell_array[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band=band)[0]
+                    try:
+                        cell_array[:, :, i] -= self.find_dark_img(self.cell_cal_dir, ss=ss, band=band)[0]
+                    except np.core._exceptions._UFuncOutputCastingError:
+                        print('Unable to find dark image for cell calibration in '
+                                      'band {} exposure {}. Image will not be dark-subtracted'.format(band, ss))
+
 
                     # Scale image to 1 second exposure (so that we can deal with images of different shutter speeds
                     cell_array[:, :, i] *= (1 / meta['texp'])


### PR DESCRIPTION
Goes some way to removing the likelihood of #277 although this isn't a direct fix of that.

Clear sky images are now flagged as dark subtracted whether or not a dark image can be found for their shutter speed. A warning is raised if a dark image can't be found. This is in line with how plume images are dealt with if a dark image can't be found. 

More consideration should be given to #278 so that, rather than not subtracting any dark image, the nearest shutter speed dark image is subtracted. This would be optimal.

This PR also makes cell calibration more flexible with lack of dark images. Again, printing a warning rather than failing if dakr images aren't present.