### PR TITLE
Add logging to DOAS related modules 

### DIFF
--- a/pycam/directory_watcher.py
+++ b/pycam/directory_watcher.py
@@ -433,6 +433,9 @@ try:
                 if not path:  # probably an exit request
                     continue
 
+                if '.log' in path:
+                    continue
+
                 # Ignore lock files as otherwise this watcher recreates the file - not good
                 if '.lock' in path:
                     continue

--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -17,6 +17,7 @@ from tkinter import filedialog
 from pycam.setupclasses import SpecSpecs
 from pycam.io_py import load_spectrum
 from pycam.doas.spec_worker import SpecWorker, SpectraError
+from pycam.logging.logging_tools import LoggerManager
 from pydoas.analysis import DoasResults
 
 warnings.filterwarnings("ignore", category=OptimizeWarning)
@@ -582,6 +583,10 @@ class DOASWorker(SpecWorker):
 
         # Stop the processing thread
         self.q_spec.put('exit')
+
+        LoggerManager.remove_file_handler(self.SpecLogger, self.log_path)
+        LoggerManager.remove_file_handler(self.SpecDirWatchLogger, self.log_path)
+        LoggerManager.delete_file_handler(self.log_path)
 
     def directory_watch_handler(self, pathname, t):
         """Handles new spectra passed from watcher"""

--- a/pycam/doas/doas_worker.py
+++ b/pycam/doas/doas_worker.py
@@ -16,7 +16,6 @@ from scipy.optimize import curve_fit, OptimizeWarning
 from tkinter import filedialog
 from pycam.setupclasses import SpecSpecs
 from pycam.io_py import load_spectrum
-from pycam.directory_watcher import create_dir_watcher
 from pycam.doas.spec_worker import SpecWorker, SpectraError
 from pydoas.analysis import DoasResults
 
@@ -575,25 +574,6 @@ class DOASWorker(SpecWorker):
             if first_spec:
                 # Now that we have processed first_spec, set flag to False
                 first_spec = False
-
-    def start_watching(self, directory):
-        """
-        Setup directory watcher for images - note this is not for watching spectra - use DOASWorker for that
-        Also starts a processing thread, so that the images which arrive can be processed
-        """
-        if self.watching:
-            print('Already watching for spectra: {}'.format(self.transfer_dir))
-            print('Please stop watcher before attempting to start new watch. '
-                  'This isssue may be caused by having manual acquisitions running alongside continuous watching')
-            return
-        self.watcher = create_dir_watcher(directory, True, self.directory_watch_handler)
-        self.watcher.start()
-        self.transfer_dir = directory
-        self.watching = True
-        print('Watching {} for new spectra'.format(self.transfer_dir[-30:]))
-
-        # Start the processing thread
-        self.start_processing_thread()
 
     def stop_watching(self):
         """Stop directory watcher and end processing thread"""

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -866,6 +866,10 @@ class IFitWorker(SpecWorker):
 
                 # Stop processing thread when we stop watching the directory
                 self.q_spec.put(self.STOP_FLAG)
+
+                LoggerManager.remove_file_handler(self.SpecLogger, self.log_path)
+                LoggerManager.remove_file_handler(self.SpecDirWatchLogger, self.log_path)
+                LoggerManager.delete_file_handler(self.log_path)
             else:
                 self.SpecDirWatchLogger.warning('No directory watcher to stop')
         else:

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -472,8 +472,8 @@ class IFitWorker(SpecWorker):
                                                                        wavelengths=self.wavelengths,
                                                                        spectra=self.plume_spec_shift,
                                                                        spec_time=self.spec_time)
-                    self.SpecLogger.info(f'Fit val uncorrected: {fit_0.params['SO2'].fit_val}')
-                    self.SpecLogger.info(f'Fit val corrected: {df_lookup['SO2'][0]}')
+                    self.SpecLogger.info(f'Fit val uncorrected: {fit_0.params["SO2"].fit_val}')
+                    self.SpecLogger.info(f'Fit val corrected: {df_lookup["SO2"][0]}')
                     # Update SO2 value for the best SO2 value we have
                     if not np.isnan(df_lookup['SO2'][0]):
                         fit_0.params['SO2'].fit_val = df_lookup['SO2'][0]
@@ -524,7 +524,8 @@ class IFitWorker(SpecWorker):
 
         # Loop through directory plume images processing them
         for i in range(len(self.spec_dict['plume'])):
-            self.SpecLogger.info(f'Processing spectrum {i+1} of {len(self.spec_dict['plume'])}')
+            self.SpecLogger.info(f'Processing spectrum {i+1} of {len(self.spec_dict["plume"])}')
+            
 
             self.wavelengths, self.plume_spec_raw = load_spectrum(os.path.join(self.spec_dir,
                                                                                self.spec_dict['plume'][i]))
@@ -1341,7 +1342,7 @@ class IFitWorker(SpecWorker):
                 # Change analyser values
                 self.analyser0.params['LDF'].set(value=ldf_best)
                 self.analyser1.params['LDF'].set(value=ldf_best)
-            self.SpecLogger.info(f'LDF: {self.analyser0.params['LDF'].value}')
+            self.SpecLogger.info(f'LDF: {self.analyser0.params["LDF"].value}')
 
             # Fit spectrum for in 2 fit windows
             fit0 = self.analyser0.fit_spectrum([wavelengths[i], spectra[i]], calc_od=['SO2', 'Ring', 'O3'],

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -711,14 +711,11 @@ class IFitWorker(SpecWorker):
         self.log_path = os.path.join(self.doas_outdir, "SpecWorker.log")
 
         LoggerManager.add_file_handler(self.SpecLogger, self.log_path)
-        LoggerManager.add_file_handler(self.SpecDirWatchLogger, self.log_path)
 
         # Begin processing
         self._process_loop(continuous_save=False)
 
-        LoggerManager.remove_file_handler(self.SpecLogger, self.log_path)
-        LoggerManager.remove_file_handler(self.SpecDirWatchLogger, self.log_path)
-        LoggerManager.delete_file_handler(self.log_path)
+        LoggerManager.remove_file_handler(self.SpecLogger, self.log_path, delete=True)
 
     def _process_loop(self, continuous_save=True):
         """

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -20,7 +20,6 @@ from scipy.interpolate import griddata
 from matplotlib.pyplot import GridSpec
 from shapely.geometry import Point, Polygon     # For Varnam light dilution
 from shapely.strtree  import STRtree
-from pycam.directory_watcher import create_dir_watcher
 from pycam.setupclasses import SpecSpecs, FileLocator
 from pycam.io_py import load_spectrum
 from pycam.ifit_ld import lookup
@@ -854,27 +853,6 @@ class IFitWorker(SpecWorker):
     def stop_sequence_processing(self):
         """Stops processing a sequence"""
         self.q_stop.put(self.STOP_FLAG)
-
-    def start_watching(self, directory, recursive=True):
-        """
-        Setup directory watcher for images - note this is not for watching spectra - use DOASWorker for that
-        Also starts a processing thread, so that the images which arrive can be processed
-        """
-        if self.watching:
-            self.SpecDirWatchLogger.warning(
-                f'Already watching for spectra: {self.transfer_dir}\n'
-                f'Please stop watcher before attempting to start new watch. This isssue may be '
-                f'caused by having manual acquisitions running alongside continuous watching'
-            )
-            return
-        self.watcher = create_dir_watcher(directory, recursive, self.directory_watch_handler)
-        self.watcher.start()
-        self.transfer_dir = directory
-        self.watching = True
-        self.SpecDirWatchLogger.info(f'Watching {self.transfer_dir[-30:]} for new spectra')
-
-        # Start the processing thread
-        self.start_processing_thread()
 
     def stop_watching(self):
         """Stop directory watcher and end processing thread"""

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -709,7 +709,7 @@ class IFitWorker(SpecWorker):
 
         # Need to generate output dir at the start of processing to create log file
         self.set_output_dir(self.spec_dir)
-        self.log_path = os.path.join(self.doas_outdir, "SpecWorker.log")
+        self.log_path = Path(self.doas_outdir).joinpath("SpecWorker.log").as_posix()
 
         LoggerManager.add_file_handler(self.SpecLogger, self.log_path)
 
@@ -806,8 +806,7 @@ class IFitWorker(SpecWorker):
 
                 time_1 = time.time()
                 self.process_doas()
-                process_duration = time.time() - time_1
-                self.SpecLogger.info(f'Time taken to process {pathname}: {process_duration:.5f}')
+                self.SpecLogger.info(f'Time taken to process {pathname}: {time.time() - time_1:.5f}')
 
                 # Gather all relevant information and spectra and pass it to PyplisWorker
                 processed_dict = {'processed': True,             # Flag whether this is a complete, processed dictionary

--- a/pycam/doas/ifit_worker.py
+++ b/pycam/doas/ifit_worker.py
@@ -320,10 +320,10 @@ class IFitWorker(SpecWorker):
             if len(spec_dir) > 0 and os.path.exists(spec_dir):
                 self.spec_dir = spec_dir
             else:
-                raise ValueError('Spectrum directory not recognised: {}'.format(spec_dir))
+                raise ValueError(f'Spectrum directory not recognised: {spec_dir}')
         else:
             if self.spec_dir is None:
-                raise ValueError('Spectrum directory not recognised: {}'.format(self.spec_dir))
+                raise ValueError(f'Spectrum directory not recognised: {self.spec_dir}')
 
         # Update first_spec flag TODO possibly not used in DOASWorker, check
         self.first_spec = True
@@ -743,7 +743,7 @@ class IFitWorker(SpecWorker):
 
             # Blocking wait for new file
             pathname = self.q_spec.get(block=True)
-            self.SpecLogger.info('Got new file: {}'.format(pathname))
+            self.SpecLogger.debug(f'Got new file: {pathname}')
 
             # Close thread if requested with 'exit' command
             if pathname == self.STOP_FLAG:
@@ -1108,9 +1108,9 @@ class IFitWorker(SpecWorker):
 
         dat = np.load(file_path)
         x, y = dat  # unpack data into cd and error grids
-        setattr(self, 'ifit_so2_{}'.format(fit_num), x)
-        setattr(self, 'ifit_err_{}'.format(fit_num), y)
-        setattr(self, 'ifit_so2_{}_path'.format(fit_num), file_path)
+        setattr(self, f'ifit_so2_{fit_num}', x)
+        setattr(self, f'ifit_err_{fit_num}', y)
+        setattr(self, f'ifit_so2_{fit_num}_path', file_path)
 
         # Extract grid info from filename
         filename = os.path.split(file_path)[-1]

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -544,11 +544,8 @@ class SpecWorker:
             )
             return
         
-        self.set_output_dir(directory)
-        self.log_path = os.path.join(self.doas_outdir, "SpecWorker.log")
-
-        LoggerManager.add_file_handler(self.SpecLogger, self.log_path)
-        LoggerManager.add_file_handler(self.SpecDirWatchLogger, self.log_path)
+        LoggerManager.add_mem_handler(self.SpecLogger, "SpecWorker")
+        LoggerManager.add_mem_handler(self.SpecDirWatchLogger, "SpecWorker")
 
         self.watcher = create_dir_watcher(directory, recursive, self.directory_watch_handler)
         self.watcher.start()

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -216,7 +216,7 @@ class SpecWorker:
         """If dark_dir is changed we need to reset the dark_dict which holds preloaded dark specs"""
         self.dark_dict = {}
         self._dark_dir = value
-        self.SpecLogger.info(f'Dark spectra directory set: {self.dark_dir}')
+        self.SpecLogger.debug(f'Dark spectra directory set: {self.dark_dir}')
 
     @property
     def clear_spec_raw(self):
@@ -318,7 +318,7 @@ class SpecWorker:
         after first interpolating to spectrometer wavelengths
         """
         if self.wavelengths is None:
-            self.SpecLogger.info('No wavelength data to perform convolution')
+            self.SpecLogger.debug('No wavelength data to perform convolution')
             return
 
         # Need an odd sized array for convolution, so if even we omit the last pixel

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -545,6 +545,10 @@ class SpecWorker:
             return
         
         self.set_output_dir(directory)
+        self.log_path = os.path.join(self.doas_outdir, "SpecWorker.log")
+
+        LoggerManager.add_file_handler(self.SpecLogger, self.log_path)
+        LoggerManager.add_file_handler(self.SpecDirWatchLogger, self.log_path)
 
         self.watcher = create_dir_watcher(directory, recursive, self.directory_watch_handler)
         self.watcher.start()

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -559,9 +559,6 @@ class SpecWorker:
         # Start the processing thread
         self.start_processing_thread()
 
-    def reset_self(self):
-        pass
-
 class SpectraError(Exception):
     """
     Error raised if correct spectra aren't present for processing

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -216,7 +216,7 @@ class SpecWorker:
         """If dark_dir is changed we need to reset the dark_dict which holds preloaded dark specs"""
         self.dark_dict = {}
         self._dark_dir = value
-        print('Dark spectra directory set: {}'.format(self.dark_dir))
+        self.SpecLogger.info(f'Dark spectra directory set: {self.dark_dir}')
 
     @property
     def clear_spec_raw(self):
@@ -318,7 +318,7 @@ class SpecWorker:
         after first interpolating to spectrometer wavelengths
         """
         if self.wavelengths is None:
-            print('No wavelength data to perform convolution')
+            self.SpecLogger.info('No wavelength data to perform convolution')
             return
 
         # Need an odd sized array for convolution, so if even we omit the last pixel
@@ -476,14 +476,14 @@ class SpecWorker:
             f.write('Light dilution correction used (on/off)={}\n'.format(self.corr_light_dilution))
             f.write('Light dilution recal time [mins]={}\n'.format(self.recal_ld_mins))
 
-        print('DOAS processing parameters saved: {}'.format(filepath))
+        self.SpecLogger.info(f'DOAS processing parameters saved: {filepath}')
 
     def save_results(self, pathname=None, start_time=None, end_time=None, save_last=False, header=True):
         """Saves doas results"""
 
         # Only continue if there are results to save
         if len(self.results) < 1:
-            print('No DOAS results to save')
+            self.SpecLogger.info('No DOAS results to save')
             return
 
         # Need to generate a filename if one doesn't already exist/isn't provided
@@ -526,7 +526,7 @@ class SpecWorker:
         df.to_csv(pathname, mode = 'a', header = header, index = False)
 
         # Not sure we want to print every time
-        print('DOAS results saved: {}'.format(pathname))
+        self.SpecLogger.info(f'DOAS results saved: {pathname}')
 
 
 class SpectraError(Exception):

--- a/pycam/doas/spec_worker.py
+++ b/pycam/doas/spec_worker.py
@@ -10,6 +10,7 @@ from astropy.convolution import convolve
 from pycam.setupclasses import SpecSpecs
 from pydoas.analysis import DoasResults
 from pycam.io_py import load_spectrum
+from pycam.logging.logging_tools import LoggerManager
 
 try:
     from scipy.constants import N_A
@@ -20,8 +21,12 @@ class SpecWorker:
     """
     Parent class for IfitWorker and DoasWorker
     """
+    SpecLogger = LoggerManager.add_logger("SpecWorker", "blue")
+    SpecDirWatchLogger = LoggerManager.add_logger("SpecDirWatcher", "purple")
+
     def __init__(self, routine=2, species={'SO2': {'path': '', 'value': 0}}, spec_specs=SpecSpecs(), spec_dir='C:/', dark_dir=None,
                  q_doas=queue.Queue()):
+        self.SpecLogger.debug("Initialising SpecWorker")
         self.routine = routine          # Defines routine to be used, either (1) Polynomial or (2) Digital Filtering
         self.spec_specs = spec_specs    # Spectrometer specifications
 

--- a/pycam/gui/figures_doas.py
+++ b/pycam/gui/figures_doas.py
@@ -845,7 +845,7 @@ class RefPlot:
     species: str
         Defines the species for reference spectrum
     """
-    def __init__(self, frame=None, doas_work=DOASWorker(), init_dir='./', ref_spec_path=None, species='SO2',
+    def __init__(self, frame=None, doas_work=doas_worker, init_dir='./', ref_spec_path=None, species='SO2',
                  fig_setts=GUISettings()):
         self.frame = frame
         self.doas_worker = doas_work  # DOAS processor
@@ -984,7 +984,7 @@ class ILSFrame:
     """
     Frame containing widgets for ILS extraction from a calibration spectrum
     """
-    def __init__(self, parent=None, doas_work=DOASWorker(), spec_specs=SpecSpecs(), fig_setts=GUISettings(),
+    def __init__(self, parent=None, doas_work=doas_worker, spec_specs=SpecSpecs(), fig_setts=GUISettings(),
                  config=pyplis_worker.config, save_path='C:/'):
         # Setup some main variables
         self.parent = parent

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -2,6 +2,15 @@ import logging
 from pathlib import Path
 from logging.handlers import TimedRotatingFileHandler
 
+def remove_stream_handler(logger):
+    """ Removes all stream handlers from logger provided.
+
+    :param logger logger: logger object to remove stream handler from
+    """
+    for handler in logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            logger.removeHandler(handler)
+
 # Set up the root logger
 root_logger = logging.getLogger()
 

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -64,32 +64,21 @@ class LoggerManager:
         logger.addHandler(LoggerManager._file_handlers[file_handler_key])
 
     @staticmethod
-    def remove_file_handler(logger, log_path):
+    def remove_file_handler(logger, log_path, delete=False):
         """ Remove Filehandler from an existing logger. Removed based on the path to the log file.
 
         :param logger logger: Existing logger to remove FileHandler from
-        :param (str|Path) log_path: Location of the log file
+        :param (str|Path) log_path: Location of the log file, used as a key to identify a handler
+        :param bool delete: Close and delete the file handler after removal, Defaults to False
         """
-        log_path = Path(log_path).resolve()
-        for handler in logger.handlers:
-            if isinstance(handler, logging.FileHandler):
-                handler_path = Path(handler.baseFilename).resolve()
-                if handler_path == log_path:
-                    logger.removeHandler(handler)
 
-    @staticmethod
-    def delete_file_handler(log_path):
-        """ Close and delete a saved FileHandler
+        log_path = Path(log_path).as_posix()
+        if log_path in LoggerManager._file_handlers:
+            logger.removeHandler(LoggerManager._file_handlers[log_path])
 
-        :param (str|Path) log_path: _description_
-        """
-        log_path = Path(log_path)
-        try:
-            handler = LoggerManager._file_handlers[log_path]
-            handler.close()
-            del LoggerManager._file_handlers[log_path]
-        except KeyError:
-            pass
+            if delete:
+                LoggerManager._file_handlers[log_path].close()
+                del LoggerManager._file_handlers[log_path]
 
     @staticmethod
     def remove_stream_handlers(logger):

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -75,19 +75,12 @@ root_logger = logging.getLogger()
 # If the root logger doesn't have a file handler then add one
 if not any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers):
     # Start by defining the root log path
-    root_log_path = Path.home() / "pycam_logs" / "root.log"
-    root_log_path.parent.mkdir(parents=True, exist_ok=True)
+    root_log_path = Path.home() / "pycam_logs/root.log"
 
-    # Then setup a file handler and formatter for the root logger
-    root_file_handler = TimedRotatingFileHandler(
-        root_log_path, when = 'D', interval=1, backupCount=5
-    )
-    root_file_formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        '%Y-%m-%d %H:%M:%S'
-    )
-
-    root_file_handler.setFormatter(root_file_formatter)
-    root_logger.addHandler(root_file_handler)
-
+    # Add the file handler
+    LoggerManager.add_file_handler(root_logger, root_log_path, level = logging.INFO)
+    
+    root_logger.setLevel(logging.INFO)
+    
+    # Log message on creation
     root_logger.info("New session started")

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -20,7 +20,7 @@ class LoggerManager:
         :param str name: Name of the logger to create
         :param str colour: Colour of the text used for logging messages, defaults to white
         :param int level: Logging level to set for the StreamHandler, defaults to logging.DEBUG
-        :return logger: Reference to logger
+        :return logging.Logger: Newly created logger
         """
 
         if name not in LoggerManager._loggers:
@@ -156,13 +156,13 @@ class LoggerManager:
             if isinstance(handler, logging.StreamHandler):
                 logger.removeHandler(handler)
 
-# Set up the root logger
+# Get the root logger
 root_logger = logging.getLogger()
 
 # If the root logger doesn't have a file handler then add one
 if not any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers):
     # Start by defining the root log path
-    root_log_path = Path.home() / "pycam_logs/root.log"
+    root_log_path = Path.home() / "pycam_logs" / "root.log"
 
     # Add the file handler
     LoggerManager.add_file_handler(root_logger, root_log_path, level = logging.INFO)

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from logging.handlers import TimedRotatingFileHandler
 
 class LoggerManager:
-    """ Class for manging creation of loggers and creation and deltion of handlers 
+    """ Class for managing creation of loggers and creation and deletion of handlers 
     for PyCam software
     """
 

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -27,13 +27,8 @@ class LoggerManager:
             logger = logging.getLogger(name)
             logger.setLevel(logging.DEBUG)
             if not logger.handlers:  # Only configure if no handlers exist
-                # Configure the logger (e.g., set level, add handlers)
-                format_str = f'%(log_color)s%(levelname)-8s%(reset)s%(asctime)s - %({colour})s%(name)s - %(message)s'
-                formatter = colorlog.ColoredFormatter(format_str, '%Y-%m-%d %H:%M:%S')
-                handler = colorlog.StreamHandler() # Output to console
-                handler.setFormatter(formatter)
-                handler.setLevel(level)  # Set the desired logging level
-                logger.addHandler(handler)
+                stream_handler = LoggerManager.create_stream_handler(colour, level)
+                logger.addHandler(stream_handler)
             LoggerManager._loggers[name] = logger
         return LoggerManager._loggers[name]
     
@@ -155,6 +150,31 @@ class LoggerManager:
         for handler in logger.handlers:
             if isinstance(handler, logging.StreamHandler):
                 logger.removeHandler(handler)
+
+    @staticmethod
+    def replace_stream_handlers(logger, colour = "white", level = logging.ERROR):
+        """ Replaces stream handlers to be more consistent with PyCam.
+
+        :param logging.Logger logger: Logger object to modify
+        :param str colour: Colour for output of new stream handler
+        :param int level: Logging level for the stream handler, defaults to logging.WARNING
+        """
+        # Start by removing current handlers
+        LoggerManager.remove_stream_handlers(logger)
+
+        # Now create a new handler
+        stream_handler = LoggerManager.create_stream_handler(colour, level)
+        logger.addHandler(stream_handler)
+
+    @staticmethod
+    def create_stream_handler(colour, level):
+        format_str = f'%(log_color)s%(levelname)-8s%(reset)s%(asctime)s - %({colour})s%(name)s - %(message)s'
+        formatter = colorlog.ColoredFormatter(format_str, '%Y-%m-%d %H:%M:%S')
+        handler = colorlog.StreamHandler() # Output to console
+        handler.setFormatter(formatter)
+        handler.setLevel(level)  # Set the desired logging level
+
+        return handler
 
 # Get the root logger
 root_logger = logging.getLogger()

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -4,31 +4,70 @@ from pathlib import Path
 from logging.handlers import TimedRotatingFileHandler
 
 class LoggerManager:
+    """ Class for manging creation of loggers and creation and deltion of handlers 
+    for PyCam software
+    """
+
     _loggers = {}  # Store created loggers to prevent duplicates
+    _file_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s', '%Y-%m-%d %H:%M:%S')
 
     @staticmethod
-    def add_logger(name, colour):
+    def add_logger(name, colour = "white", level = logging.INFO):
+        """ Add a named logger.
+
+        :param str name: Name of the logger to create
+        :param str colour: Colour of the text used for logging messages, defaults to white
+        :param int level: Logging level to set for the StreamHandler, defaults to logging.DEBUG
+        :return logger: Reference to logger
+        """
+
         if name not in LoggerManager._loggers:
             logger = logging.getLogger(name)
+            logger.setLevel(logging.DEBUG)
             if not logger.handlers:  # Only configure if no handlers exist
                 # Configure the logger (e.g., set level, add handlers)
                 format_str = f'%(log_color)s%(levelname)-8s%(reset)s%(asctime)s - %({colour})s%(name)s - %(message)s'
                 formatter = colorlog.ColoredFormatter(format_str, '%Y-%m-%d %H:%M:%S')
                 handler = colorlog.StreamHandler() # Output to console
                 handler.setFormatter(formatter)
+                handler.setLevel(level)  # Set the desired logging level
                 logger.addHandler(handler)
-                logger.setLevel(logging.DEBUG)  # Set the desired logging level
             LoggerManager._loggers[name] = logger
         return LoggerManager._loggers[name]
+    
+    @staticmethod
+    def add_file_handler(logger, log_path, level=logging.DEBUG):
+        """ Add FileHandler to an existing logger. If the log path is new then create a new handler,
+        if not then use the existing one stored in the handler dict.
 
-def remove_stream_handler(logger):
-    """ Removes all stream handlers from logger provided.
+        :param logger logger: Existing logger to add FileHandler to
+        :param (str|Path) log_path: Location to write the log file to
+        :param int level: Logging level to set for the FileHandler, defaults to logging.DEBUG
+        """
+        log_path = Path(log_path)
+        try:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            print(f"Error creating log file: {e}")
 
-    :param logger logger: logger object to remove stream handler from
-    """
-    for handler in logger.handlers:
-        if isinstance(handler, logging.StreamHandler):
-            logger.removeHandler(handler)
+        file_handler_key = str(log_path)  # Use log file path as key
+        if file_handler_key not in LoggerManager._file_handlers:
+            file_handler = TimedRotatingFileHandler(log_path, when = 'D', interval=1, backupCount=5)
+            file_handler.setFormatter(LoggerManager._file_formatter)
+            file_handler.setLevel(level)
+            LoggerManager._file_handlers[file_handler_key] = file_handler
+        
+        logger.addHandler(LoggerManager._file_handlers[file_handler_key])
+
+    @staticmethod
+    def remove_stream_handlers(logger):
+        """ Removes all stream handlers from logger provided.
+
+        :param logger logger: logger object to remove stream handlers from
+        """
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                logger.removeHandler(handler)
 
 # Set up the root logger
 root_logger = logging.getLogger()

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -1,0 +1,28 @@
+import logging
+from pathlib import Path
+from logging.handlers import TimedRotatingFileHandler
+
+# Set up the root logger
+root_logger = logging.getLogger()
+
+# If the root logger doesn't have a file handler then add one
+if not any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers):
+    # Start by defining the root log path
+    root_log_path = Path.home() / "pycam_logs" / "root.log"
+    root_log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Then setup a file handler and formatter for the root logger
+    root_file_handler = TimedRotatingFileHandler(
+        root_log_path, when = 'D', interval=1, backupCount=5
+    )
+    root_file_formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+        '%Y-%m-%d %H:%M:%S'
+    )
+
+    root_file_handler.setFormatter(root_file_formatter)
+    root_logger.addHandler(root_file_handler)
+    root_logger.setLevel(logging.INFO)
+
+    root_logger.info("New session started")
+

--- a/pycam/logging/logging_tools.py
+++ b/pycam/logging/logging_tools.py
@@ -1,6 +1,25 @@
 import logging
+import colorlog
 from pathlib import Path
 from logging.handlers import TimedRotatingFileHandler
+
+class LoggerManager:
+    _loggers = {}  # Store created loggers to prevent duplicates
+
+    @staticmethod
+    def add_logger(name, colour):
+        if name not in LoggerManager._loggers:
+            logger = logging.getLogger(name)
+            if not logger.handlers:  # Only configure if no handlers exist
+                # Configure the logger (e.g., set level, add handlers)
+                format_str = f'%(log_color)s%(levelname)-8s%(reset)s%(asctime)s - %({colour})s%(name)s - %(message)s'
+                formatter = colorlog.ColoredFormatter(format_str, '%Y-%m-%d %H:%M:%S')
+                handler = colorlog.StreamHandler() # Output to console
+                handler.setFormatter(formatter)
+                logger.addHandler(handler)
+                logger.setLevel(logging.DEBUG)  # Set the desired logging level
+            LoggerManager._loggers[name] = logger
+        return LoggerManager._loggers[name]
 
 def remove_stream_handler(logger):
     """ Removes all stream handlers from logger provided.
@@ -31,7 +50,5 @@ if not any(isinstance(handler, logging.FileHandler) for handler in root_logger.h
 
     root_file_handler.setFormatter(root_file_formatter)
     root_logger.addHandler(root_file_handler)
-    root_logger.setLevel(logging.INFO)
 
     root_logger.info("New session started")
-

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -5,7 +5,7 @@
 Scripts are an edited version of the pyplis example scripts, adapted for use with the PiCam"""
 from __future__ import (absolute_import, division)
 
-from pycam.logging.logging_tools import remove_stream_handler
+from pycam.logging.logging_tools import LoggerManager
 from pycam.setupclasses import CameraSpecs, SpecSpecs, FileLocator
 from pycam.utils import calc_dt, get_horizontal_plume_speed
 from pycam.io_py import (
@@ -58,9 +58,9 @@ path_params = [
 ]
 
 # Remove StreamHandlers from pyplis loggers so messages from pyplis just get passed to the
-# root FileHandlers
-remove_stream_handler(pyplis.print_log)
-remove_stream_handler(pyplis.logger)
+# root FileHandler
+LoggerManager.remove_stream_handlers(pyplis.print_log)
+LoggerManager.remove_stream_handlers(pyplis.logger)
 
 class PyplisWorker:
     """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -59,8 +59,8 @@ path_params = [
 
 # Remove StreamHandlers from pyplis loggers so messages from pyplis just get passed to the
 # root FileHandler
-LoggerManager.remove_stream_handlers(pyplis.print_log)
-LoggerManager.remove_stream_handlers(pyplis.logger)
+LoggerManager.replace_stream_handlers(pyplis.print_log)
+LoggerManager.replace_stream_handlers(pyplis.logger)
 
 class PyplisWorker:
     """

--- a/pycam/so2_camera_processor.py
+++ b/pycam/so2_camera_processor.py
@@ -5,6 +5,7 @@
 Scripts are an edited version of the pyplis example scripts, adapted for use with the PiCam"""
 from __future__ import (absolute_import, division)
 
+from pycam.logging.logging_tools import remove_stream_handler
 from pycam.setupclasses import CameraSpecs, SpecSpecs, FileLocator
 from pycam.utils import calc_dt, get_horizontal_plume_speed
 from pycam.io_py import (
@@ -55,6 +56,11 @@ path_params = [
     "pcs_lines", "img_registration", "dil_lines", "ld_lookup_1", "ld_lookup_2", "ILS_path", "default_cam_geom", "cal_series_path",
     "species_paths"
 ]
+
+# Remove StreamHandlers from pyplis loggers so messages from pyplis just get passed to the
+# root FileHandlers
+remove_stream_handler(pyplis.print_log)
+remove_stream_handler(pyplis.logger)
 
 class PyplisWorker:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pyinotify ; sys_platform == 'linux'
 pyplis @ git+https://github.com/volcanotech-sw/pyplis.git@sources_fix_312
 pydoas @ git+https://github.com/volcanotech-sw/pydoas.git@typing_updates
 iFit @ git+https://github.com/volcanotech-sw/iFit.git@make-pip-install
+colorlog


### PR DESCRIPTION
This is the first part of adding logging, and focussed on `SpecWorker` and `IFitWorker`.

As it stands these are logging to the console, and also writing to a general logging file (found in your home directory + `/pycam_logs/root.log`, e.g.: `C:\Users\Daniel\pycam_logs\root.log`), but everything is being written at the `INFO` level (see [here](https://docs.python.org/3.12/library/logging.html#logging-levels) for more details about the levels).

You don't want all of these messages to appear in the console, to do this I can either:
1. Set the messages you want to hide to the `DEBUG` level
2. Set the level filter to `WARNING` and set the messages you want to keep to warning
3. Set up a level between `INFO` and `WARNING`, specifically for processing related messages you want to see in the console.

Option 3 feels like the one that fits best to me (the message you don't want to see aren't really debug info, and the ones you do aren't really warnings), but it will take a little more work to set up. What do you think?

It would also be good if you could identify a couple of messages that you'd like to appear and a couple you'd like to hide from the console, just so I can get an idea.