### PR TITLE
try to patch out seabreeze ipv4 device scanning

### DIFF
--- a/pycam/controllers.py
+++ b/pycam/controllers.py
@@ -813,6 +813,13 @@ class Spectrometer(SpecSpecs):
 
                 seabreeze.use("pyseabreeze")
                 import seabreeze.spectrometers as sb
+
+                # to keep pyseabreeze from trying to IPv4 and fail with an OSError 19
+                # we'll patch out the IPv4 list_devices function to return an empty list
+                # and hence skip that section of the code
+                from unittest.mock import patch
+                patch("seabreeze.pyseabreeze.api.IPv4Transport.list_devices", lambda *_, **__: [])
+                
             except ModuleNotFoundError:
                 warnings.warn(
                     "Working on machine without seabreeze, functionality of some classes will be lost"


### PR DESCRIPTION
@tpering found in the field where the master script fails when trying to attach to the spectrometer:

![unnamed](https://github.com/user-attachments/assets/667c30c4-8b33-460d-bd6d-ad5a8ee916b5)

Commenting out 

```python
        for ipv4_dev in IPv4Transport.list_devices(**self._kwargs):
            # get the correct communication interface
            dev = _seabreeze_device_factory(ipv4_dev)
            if not dev.is_open:
                # opening the device will populate its serial number
                try:
                    dev.open()
                except RuntimeError:
                    raise
                else:
                    dev.close()
            devices.append(dev)  # type: ignore
```

in `/home/pi/.local/lib/python3.11/site-packages/seabreeze/pyseabreeze/api.py` appears to resolve the issue ([the lines in context](https://github.com/ap--/python-seabreeze/blob/4876cd77a8701394fd8c488359e2a3265bee9a7d/src/seabreeze/pyseabreeze/api.py#L137-L148)).

To avoid that section running, I think we can patch the `IPv4Transport.list_devices()` function to a lambda that returns an empty list in the same way that you might mock functionality in a test.